### PR TITLE
Moved scripts into footer for performance and security reasons.

### DIFF
--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -25,7 +25,6 @@ $userBar = $this->partial('common/user-bar', ['site' => $site]);
         <?php echo $this->headTitle(); ?>
         <?php echo $this->headLink(); ?>
         <?php echo $this->headStyle(); ?>
-        <?php echo $this->headScript(); ?>
     </head>
 
     <?php echo $this->htmlElement('body'); ?>
@@ -58,5 +57,6 @@ $userBar = $this->partial('common/user-bar', ['site' => $site]);
                 <?php echo $this->translate('Powered by Omeka S'); ?>
             <?php endif; ?>
         </footer>
+        <?php echo $this->headScript(); ?>
     </body>
 </html>


### PR DESCRIPTION
It is generally recommanded to include all scripts in the bottom of the page for performance (quicker load on small devices), security (no inline js), accessibility (no issues with js), and semantic (strict separation between content and display) reasons.

It may imply some changes on some modules or themes that includes js code inline, in particular with a jQuery or an Omeka js dependency. So if this change is accepted, it can be included with the 1.2 release (https://github.com/omeka/omeka-s/issues/1250).