### PR TITLE
Add the 'eye-slash' icon to the private properties.

### DIFF
--- a/asset/sass/_screen.scss
+++ b/asset/sass/_screen.scss
@@ -871,6 +871,12 @@ body.resource #content > h2:first-of-type + h3 {
     font-size: .5 * $base-font-size;
 }
 
+.property .private:after {
+    content: "\f070";
+    font-family: "Font Awesome 5 Free";
+    font-size: .75 * $base-font-size;
+}
+
 #content .media.resource {
     display: inline-block;
     text-align: center;


### PR DESCRIPTION
The item view (item/show.phtml) displays all properties including private properties when you are logging in as the administrator. This feature is sometimes helpful but sometimes surprising because I misunderstood they are public (non-private).

This patch adds the 'eye-slash' icon beside those private properties like the admin dashboard.
![Screenshot from 2020-01-04 14-54-35](https://user-images.githubusercontent.com/637330/71760639-0ba5a080-2f04-11ea-8e15-9bc391c34a39.png)
